### PR TITLE
Add token frequency analysis utilities

### DIFF
--- a/PROJECT_DESCRIPTION.md
+++ b/PROJECT_DESCRIPTION.md
@@ -1,0 +1,16 @@
+# Project Description
+
+The **LLM-Analyzer** project contains small utilities for working with locally
+hosted large language models via the [OLLAMA](https://github.com/jmorganca/ollama)
+API. It focuses on exploring how text maps to token ids and provides building
+blocks for visualising token usage.
+
+Current components include:
+
+* a minimal HTTP client for the OLLAMA API,
+* scripts to let two models converse with each other,
+* tools for inspecting token indices and vocabulary size,
+* helpers to build token frequency maps for future word cloud visualisations.
+
+The repository is intended as a starting point for experimenting with
+open‑source models and analysing their token landscape.

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Utilities for experimenting with locally hosted LLMs via the [OLLAMA](https://gi
 * **Ollama client** – Lightweight wrapper around the OLLAMA HTTP API.
 * **Model conversations** – Script for making two models talk to each other.
 * **Token analysis** – Inspect the token indices and counts for arbitrary text using the `tiktoken` library.
+* **Token clouds** – Produce frequency maps of generated tokens as a basis for visualisations.
 
 ## Requirements
 
@@ -32,6 +33,15 @@ from token_analysis import TokenAnalyzer
 analyzer = TokenAnalyzer()
 print(analyzer.encode("Hello world"))
 print(analyzer.token_index("hello"))
+```
+
+### Analyse model token usage
+
+```python
+from token_cloud import analyze_model_tokens
+
+counts = analyze_model_tokens("llama2", "Hello there")
+print(counts)
 ```
 
 The repository also contains unit tests which can be executed with:

--- a/tests/test_token_cloud.py
+++ b/tests/test_token_cloud.py
@@ -1,0 +1,30 @@
+import sys
+from pathlib import Path
+from collections import Counter
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from token_analysis import TokenAnalyzer
+from token_cloud import analyze_text_tokens, analyze_model_tokens
+
+
+class DummyClient:
+    def generate(self, model: str, prompt: str, stream: bool = False) -> str:
+        assert model == "dummy"
+        assert prompt == "hi"
+        return "hello world"
+
+
+def test_analyze_text_tokens() -> None:
+    analyzer = TokenAnalyzer()
+    text = "hello world hello"
+    counts = analyze_text_tokens(text, analyzer)
+    expected = Counter(analyzer.encode(text))
+    assert counts == expected
+
+
+def test_analyze_model_tokens() -> None:
+    analyzer = TokenAnalyzer()
+    counts = analyze_model_tokens("dummy", "hi", client=DummyClient(), analyzer=analyzer)
+    expected = Counter(analyzer.encode("hello world"))
+    assert counts == expected

--- a/token_analysis.py
+++ b/token_analysis.py
@@ -25,8 +25,13 @@ class TokenAnalyzer:
     def __init__(self, encoding_name: str = "cl100k_base") -> None:
         self.encoding_name = encoding_name
         if tiktoken is not None:
-            self.encoding = tiktoken.get_encoding(encoding_name)
-            self._vocab: dict[str, int] | None = None
+            try:
+                self.encoding = tiktoken.get_encoding(encoding_name)
+                self._vocab: dict[str, int] | None = None
+            except Exception:  # pragma: no cover - fallback if encoding download fails
+                self.encoding = None
+                self._vocab = {}
+                self._next_index = 0
         else:  # pragma: no cover - minimal fallback for missing dependency
             self.encoding = None
             self._vocab = {}

--- a/token_cloud.py
+++ b/token_cloud.py
@@ -1,0 +1,53 @@
+"""Utilities for token frequency analysis of model responses."""
+from __future__ import annotations
+
+from collections import Counter
+from typing import Dict
+
+from token_analysis import TokenAnalyzer
+from ollama_client import OllamaClient
+
+
+def analyze_text_tokens(text: str, analyzer: TokenAnalyzer | None = None) -> Dict[int, int]:
+    """Return a frequency map of token ids for ``text``.
+
+    Parameters
+    ----------
+    text:
+        The text to analyse.
+    analyzer:
+        Optional :class:`TokenAnalyzer` instance. If omitted a default
+        analyzer is created.
+    """
+    analyzer = analyzer or TokenAnalyzer()
+    tokens = analyzer.encode(text)
+    return Counter(tokens)
+
+
+def analyze_model_tokens(
+    model: str,
+    prompt: str,
+    client: OllamaClient | None = None,
+    analyzer: TokenAnalyzer | None = None,
+) -> Dict[int, int]:
+    """Generate a model response and return token frequency counts.
+
+    This function queries a model via :class:`OllamaClient` and analyses the
+    token ids of the returned text. The resulting frequency map can later be
+    used to build visualisations such as token clouds.
+
+    Parameters
+    ----------
+    model:
+        Name of the model to query.
+    prompt:
+        Text prompt provided to the model.
+    client:
+        Optional OLLAMA client. If omitted a new one is created.
+    analyzer:
+        Optional token analyzer. If omitted a default one is used.
+    """
+    client = client or OllamaClient()
+    analyzer = analyzer or TokenAnalyzer()
+    response = client.generate(model, prompt, stream=False)
+    return analyze_text_tokens(response, analyzer)


### PR DESCRIPTION
## Summary
- add `token_cloud.py` for generating token frequency maps from text or OLLAMA model responses
- improve `TokenAnalyzer` to gracefully fall back when `tiktoken` can't fetch encodings
- document project scope and new token cloud features in README and PROJECT_DESCRIPTION

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689a0c72c68c83228600e5eb70cd311c