### PR TITLE
Emphasize token analysis in project description

### DIFF
--- a/PROJECT_DESCRIPTION.md
+++ b/PROJECT_DESCRIPTION.md
@@ -1,14 +1,13 @@
 # Project Description
 
-The **LLM-Analyzer** project contains small utilities for working with locally
-hosted large language models via the [OLLAMA](https://github.com/jmorganca/ollama)
-API. It focuses on exploring how text maps to token ids and provides building
-blocks for visualising token usage.
+The **LLM-Analyzer** project contains utilities for working with locally hosted
+large language models via the [OLLAMA](https://github.com/jmorganca/ollama) API.
+It explores how text maps to token ids and provides building blocks for
+analysing token usage and visualising token frequencies.
 
 Current components include:
 
 * a minimal HTTP client for the OLLAMA API,
-* scripts to let two models converse with each other,
 * tools for inspecting token indices and vocabulary size,
 * helpers to build token frequency maps for future word cloud visualisations.
 


### PR DESCRIPTION
## Summary
- streamline project overview to highlight token analysis and frequency visualisation
- remove bullet about models conversing to keep focus on token utilities

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689a441306008322a664d71ca23dd15e